### PR TITLE
fix: add a longer deletion timeout for replicated lambda functions

### DIFF
--- a/cloudfront/module/main.tf
+++ b/cloudfront/module/main.tf
@@ -181,6 +181,10 @@ resource "aws_lambda_function" "origin_request" {
   timeout          = 5
   memory_size      = 128
   publish          = true
+
+  timeouts {
+    delete = "20m"
+  }
 }
 
 resource "aws_lambda_permission" "allow_cloudfront_origin_request" {


### PR DESCRIPTION
Lambda@Edge functions can take longer than the default 10 minutes to delete, this extends the deletion time of the origin request lambda so multiple destroys don't need to be run in order to tear down the stack.