### PR TITLE
fix: ensure unique names for infrastructure resources

### DIFF
--- a/cloudfront/module/main.tf
+++ b/cloudfront/module/main.tf
@@ -332,7 +332,7 @@ resource "aws_acm_certificate" "cloudfront_cert" {
 
 resource "aws_cloudfront_cache_policy" "default_cache_policy" {
   count   = var.default_cache_policy_id == null ? 1 : 0
-  name    = "SugaDefaultCachePolicy"
+  name    = "${var.suga.stack_id}-SugaDefaultCachePolicy"
   comment = "Default cache policy for CloudFront distribution for Suga Applications"
 
   # Set TTL defaults to respect cache control headers

--- a/fargate/module/main.tf
+++ b/fargate/module/main.tf
@@ -1,6 +1,6 @@
 # Create an ECR repository
 resource "aws_ecr_repository" "repo" {
-  name = var.suga.name
+  name = "${var.suga.stack_id}-${var.suga.name}"
 }
 
 data "aws_ecr_authorization_token" "ecr_auth" {

--- a/lambda/module/main.tf
+++ b/lambda/module/main.tf
@@ -29,7 +29,7 @@ locals {
 
 # Create an ECR repository
 resource "aws_ecr_repository" "repo" {
-  name = var.suga.name
+  name = "${var.suga.stack_id}-${var.suga.name}"
   image_scanning_configuration {
     scan_on_push = var.image_scan_on_push
   }

--- a/loadbalancer/module/main.tf
+++ b/loadbalancer/module/main.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "lb" {
-  name               = var.name
+  name               = "${var.suga.stack_id}-${var.name}"
   internal           = var.internal
   load_balancer_type = var.load_balancer_type
   security_groups    = var.security_groups

--- a/loadbalancer/module/variables.tf
+++ b/loadbalancer/module/variables.tf
@@ -1,10 +1,16 @@
-variable "load_balancer_type" {
-  type    = string
-  default = "application"
+variable "suga" {
+  type = object({
+    stack_id = string
+  })
 }
 
 variable "name" {
   type = string
+}
+
+variable "load_balancer_type" {
+  type    = string
+  default = "application"
 }
 
 variable "listener_port" {

--- a/sgrule/module/variables.tf
+++ b/sgrule/module/variables.tf
@@ -1,3 +1,9 @@
+variable "suga" {
+  type = object({
+    stack_id = string
+  })
+}
+
 variable "security_group_ids" {
   type        = list(string)
   description = "List of security group IDs to which the rule will be applied"

--- a/vpc/module/main.tf
+++ b/vpc/module/main.tf
@@ -10,7 +10,7 @@ locals {
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = var.name
+  name = "${var.suga.stack_id}-${var.name}"
   cidr = var.networking.cidr_block
 
   azs             = local.azs

--- a/vpc/module/variables.tf
+++ b/vpc/module/variables.tf
@@ -1,7 +1,14 @@
+variable "suga" {
+  type = object({
+    stack_id = string
+  })
+}
+
 variable "name" {
   type        = string
   description = "The name of the VPC"
 }
+
 variable "networking" {
   type = object({
     cidr_block      = string


### PR DESCRIPTION
Resources updated to include stack_id in name - fargate, lambda, loadbalancer, vpc 

Relies on - https://github.com/nitrictech/suga/pull/103 which injects the stack_id for infra resources